### PR TITLE
Replace false image data decoding in readContents with simple skipping.

### DIFF
--- a/library/src/main/java/com/felipecsl/gifimageview/library/GifDecoder.java
+++ b/library/src/main/java/com/felipecsl/gifimageview/library/GifDecoder.java
@@ -725,14 +725,18 @@ public class GifDecoder {
 
         currentFrame.bufferFrameStart = rawData.position(); // Save this as the decoding position pointer
 
-        decodeBitmapData(null, mainPixels); // false decode pixel data to advance buffer
-        skip();
+        skipBitmapData();
         if (err()) {
             return;
         }
 
         frameCount++;
         frames.add(currentFrame); // add image to frame
+    }
+
+    private void skipBitmapData() {
+        read(); // code size
+        skip();
     }
 
     /**


### PR DESCRIPTION
This decoding was only used to advance the buffer, but we can achieve the same by just skipping image data blocks. This is much faster.
