### PR TITLE
Remove explicitly setting allowBackup to true

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
           package="com.felipecsl.gifimageview.library">
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name">
 
     </application>


### PR DESCRIPTION
There's no real reason to have it set, and if someone sets allowBackup to false in their project the build will break
