### PR TITLE
Supress any exception on Thread.sleep

### DIFF
--- a/library/src/main/java/com/felipecsl/gifimageview/library/GifImageView.java
+++ b/library/src/main/java/com/felipecsl/gifimageview/library/GifImageView.java
@@ -119,8 +119,9 @@ public class GifImageView extends ImageView implements Runnable {
                 gifDecoder.advance();
                 try {
                     Thread.sleep(gifDecoder.getNextDelay());
-                } catch (final InterruptedException e) {
-                    // suppress
+                } catch (final Exception e) {
+                    // suppress any exception
+                    // it can be InterruptedException or IllegalArgumentException
                 }
             }
         } while (animating);


### PR DESCRIPTION
getNextDelay() can return an invalid value and Thread.sleep will throw an IllegalArgumentException.
Just ignore it.
