### PR TITLE
Fallback to default frame delay if it's not specified

### DIFF
--- a/library/src/main/java/com/felipecsl/gifimageview/library/GifDecoder.java
+++ b/library/src/main/java/com/felipecsl/gifimageview/library/GifDecoder.java
@@ -698,6 +698,8 @@ public class GifDecoder {
     }
     currentFrame.transparency = (packed & 1) != 0;
     currentFrame.delay = readShort() * 10; // delay in milliseconds
+    if(currentFrame.delay<=10)
+      currentFrame.delay=100;
     currentFrame.transIndex = read(); // transparent color index
     read(); // block terminator
   }

--- a/library/src/main/java/com/felipecsl/gifimageview/library/GifDecoder.java
+++ b/library/src/main/java/com/felipecsl/gifimageview/library/GifDecoder.java
@@ -698,8 +698,9 @@ public class GifDecoder {
     }
     currentFrame.transparency = (packed & 1) != 0;
     currentFrame.delay = readShort() * 10; // delay in milliseconds
-    if(currentFrame.delay<=10)
-      currentFrame.delay=100;
+    if (currentFrame.delay <= 10) {
+      currentFrame.delay = 100;
+    }
     currentFrame.transIndex = read(); // transparent color index
     read(); // block terminator
   }


### PR DESCRIPTION
Please try this gif https://psv4.vk.me/c537619/u98835002/docs/97b6b1010e47/file317.gif
It plays fine in any gif player. But it plays super-fast in GifImageViewer.
That happens because delays are not specified in this file, all delays are zero there.
That's why I propose this modification. Fallback to 100 ms delay if it's not specified inside gif.
I have tested this modification on multiple gifs and it works just fine.
In other gif decoder implementations I can see the same fallback, for example take a look at this one https://github.com/bumptech/glide/blob/c2fc19316d8680322cabeed31234d19e942866e8/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifHeaderParser.java#L189