### PR TITLE
Sleep duration fix to respect frame decoding

### DIFF
--- a/library/src/main/java/com/felipecsl/gifimageview/library/GifImageView.java
+++ b/library/src/main/java/com/felipecsl/gifimageview/library/GifImageView.java
@@ -134,11 +134,11 @@ public class GifImageView extends ImageView implements Runnable {
           break;
         }
         //milliseconds spent on frame decode
-        long frame_decode_time = 0;
+        long frameDecodeTime = 0;
         try {
           long before = System.nanoTime();
           tmpBitmap = gifDecoder.getNextFrame();
-          frame_decode_time=(System.nanoTime()-before)/1000000;
+          frameDecodeTime = (System.nanoTime() - before) / 1000000;
           if (frameCallback != null) {
             tmpBitmap = frameCallback.onFrameAvailable(tmpBitmap);
           }
@@ -159,7 +159,7 @@ public class GifImageView extends ImageView implements Runnable {
           // Sleep for frame duration minus time already spent on frame decode
           // Actually we need next frame decode duration here,
           // but I use previous frame time to make code more readable
-          delay -= frame_decode_time;
+          delay -= frameDecodeTime;
           if (delay > 0) {
             Thread
               .sleep(framesDisplayDuration > 0 ? framesDisplayDuration : delay);

--- a/library/src/main/java/com/felipecsl/gifimageview/library/GifImageView.java
+++ b/library/src/main/java/com/felipecsl/gifimageview/library/GifImageView.java
@@ -133,8 +133,12 @@ public class GifImageView extends ImageView implements Runnable {
         if (!animating) {
           break;
         }
+        //milliseconds spent on frame decode
+        long frame_decode_time = 0;
         try {
+          long before = System.nanoTime();
           tmpBitmap = gifDecoder.getNextFrame();
+          frame_decode_time=(System.nanoTime()-before)/1000000;
           if (frameCallback != null) {
             tmpBitmap = frameCallback.onFrameAvailable(tmpBitmap);
           }
@@ -151,8 +155,15 @@ public class GifImageView extends ImageView implements Runnable {
         }
         gifDecoder.advance();
         try {
-          Thread
-              .sleep(framesDisplayDuration > 0 ? framesDisplayDuration : gifDecoder.getNextDelay());
+          int delay = gifDecoder.getNextDelay();
+          // Sleep for frame duration minus time already spent on frame decode
+          // Actually we need next frame decode duration here,
+          // but I use previous frame time to make code more readable
+          delay -= frame_decode_time;
+          if (delay > 0) {
+            Thread
+              .sleep(framesDisplayDuration > 0 ? framesDisplayDuration : delay);
+          }
         } catch (final Exception e) {
           // suppress any exception
           // it can be InterruptedException or IllegalArgumentException


### PR DESCRIPTION
Lets assume we have gif with 100 ms delay between frames.

In the current implementation user will see delay more than 100 ms because there's additional time spent on each frame decoding (it's gifDecoder.getNextFrame()). This additional time may be different depending on device performance. On some slower devices I can see additional 100, 200, even 300 ms. So instead of required 100 ms the actual delay may be 200, 300, 400 ms.

In my fix I call Thread.sleep() only if decoding time was less than required delay and we need some more sleep.

You can't see this problem on fast device. But if you try slower device or slow emulator you will see the playback looks much slower than expected. Also affects gifs with big frames that take long to decode.

I had complains from my users about that. After applying this fix they seem to be pretty happy.