### PR TITLE
Memory leak fix experiment

### DIFF
--- a/library/src/main/java/com/felipecsl/gifimageview/library/GifImageView.java
+++ b/library/src/main/java/com/felipecsl/gifimageview/library/GifImageView.java
@@ -32,9 +32,6 @@ public class GifImageView extends ImageView implements Runnable {
   private final Runnable cleanupRunnable = new Runnable() {
     @Override
     public void run() {
-      if (tmpBitmap != null && !tmpBitmap.isRecycled()) {
-        tmpBitmap.recycle();
-      }
       tmpBitmap = null;
       gifDecoder = null;
       animationThread = null;
@@ -108,6 +105,7 @@ public class GifImageView extends ImageView implements Runnable {
     animating = false;
     shouldClear = true;
     stopAnimation();
+    handler.post(cleanupRunnable);
   }
 
   private boolean canStart() {


### PR DESCRIPTION
See #27 

I added handler.post(cleanupRunnable) to release all resources. Otherwise cleanupRunnable is never invoked after calling clear()

After that I had to remove recycle() call. Because due to lack of synchronization it force closes sometimes. It happens when gifDecoder tries to do something with bitmap that we have already been recycled.

Not a big deal I guess because garbage collector will release the bitmap and it will be recycled anyway.

With this modifications it works fine for me, no more leak. But it looks confusing. Probably you have some better ideas.