### PR TITLE
Fix #30 - Illegal Argument Exception due to overflowing buffer length

### DIFF
--- a/library/src/main/java/com/felipecsl/gifimageview/library/GifHeaderParser.java
+++ b/library/src/main/java/com/felipecsl/gifimageview/library/GifHeaderParser.java
@@ -358,11 +358,14 @@ public class GifHeaderParser {
    * Skips variable length blocks up to and including next zero length block.
    */
   private void skip() {
-    int blockSize;
-    do {
-      blockSize = read();
-      rawData.position(rawData.position() + blockSize);
-    } while (blockSize > 0);
+    try {
+      int blockSize;
+      do {
+        blockSize = read();
+        rawData.position(rawData.position() + blockSize);
+      } while (blockSize > 0);
+    } catch (IllegalArgumentException ex) {
+    }
   }
 
   /**


### PR DESCRIPTION
When skipping it was going over the size of the buffer of rawDAta, in this situation an IllegalArgumentException was thrown which goes uncaught. Didn't set status to ERROR as the exception occurs when skipping to next block. So it will stop parsing on next block. 

Fixes #30.