### PR TITLE
 Fix #19 - On stop callback for when animation completes

### DIFF
--- a/app/src/main/java/com/felipecsl/gifimageview/app/MainActivity.java
+++ b/app/src/main/java/com/felipecsl/gifimageview/app/MainActivity.java
@@ -8,6 +8,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
+import android.widget.Toast;
 
 import com.felipecsl.gifimageview.library.GifImageView;
 
@@ -36,6 +37,16 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
           return blur.blur(bitmap);
         }
         return bitmap;
+      }
+    });
+
+    gifImageView.setOnAnimationStop(new GifImageView.OnAnimationStop() {
+      @Override public void onAnimationStop() {
+        MainActivity.this.runOnUiThread(new Runnable() {
+          @Override public void run() {
+            Toast.makeText(MainActivity.this, "Animation stopped", Toast.LENGTH_SHORT).show();
+          }
+        });
       }
     });
 

--- a/app/src/main/java/com/felipecsl/gifimageview/app/MainActivity.java
+++ b/app/src/main/java/com/felipecsl/gifimageview/app/MainActivity.java
@@ -42,7 +42,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     gifImageView.setOnAnimationStop(new GifImageView.OnAnimationStop() {
       @Override public void onAnimationStop() {
-        MainActivity.this.runOnUiThread(new Runnable() {
+        runOnUiThread(new Runnable() {
           @Override public void run() {
             Toast.makeText(MainActivity.this, "Animation stopped", Toast.LENGTH_SHORT).show();
           }

--- a/library/src/main/java/com/felipecsl/gifimageview/library/GifImageView.java
+++ b/library/src/main/java/com/felipecsl/gifimageview/library/GifImageView.java
@@ -19,6 +19,7 @@ public class GifImageView extends ImageView implements Runnable {
   private Thread animationThread;
   private OnFrameAvailable frameCallback = null;
   private long framesDisplayDuration = -1L;
+  private OnAnimationStop animationStopCallback = null;
 
   private final Runnable updateResults = new Runnable() {
     @Override
@@ -168,6 +169,9 @@ public class GifImageView extends ImageView implements Runnable {
         }
       }
     } while (animating);
+    if (animationStopCallback != null) {
+      animationStopCallback.onAnimationStop();
+    }
   }
 
   public OnFrameAvailable getOnFrameAvailable() {
@@ -181,4 +185,17 @@ public class GifImageView extends ImageView implements Runnable {
   public interface OnFrameAvailable {
     Bitmap onFrameAvailable(Bitmap bitmap);
   }
+
+  public OnAnimationStop getOnAnimationStop() {
+    return animationStopCallback;
+  }
+
+  public void setOnAnimationStop(OnAnimationStop animationStop) {
+    this.animationStopCallback = animationStop;
+  }
+
+  public interface OnAnimationStop {
+    void onAnimationStop();
+  }
+
 }


### PR DESCRIPTION
Added callback for onStop when animation stops. This becomes works nicely when combined with #35 (which allows GIFs with a loop count). 

Fixes #19.