### PR TITLE
Fix glitch with DISPOSAL_PREVIOUS

### DIFF
--- a/library/src/main/java/com/felipecsl/gifimageview/library/GifDecoder.java
+++ b/library/src/main/java/com/felipecsl/gifimageview/library/GifDecoder.java
@@ -546,7 +546,8 @@ class GifDecoder {
     if (previousFrame != null && previousFrame.dispose > DISPOSAL_UNSPECIFIED) {
       // We don't need to do anything for DISPOSAL_NONE, if it has the correct pixels so will our
       // mainScratch and therefore so will our dest array.
-      if (previousFrame.dispose == DISPOSAL_BACKGROUND) {
+      if (previousFrame.dispose == DISPOSAL_BACKGROUND ||
+          previousFrame.dispose == DISPOSAL_PREVIOUS && previousImage == null) {
         // Start with a canvas filled with the background color
         int c = 0;
         if (!currentFrame.transparency) {


### PR DESCRIPTION
PR for this issue: https://github.com/felipecsl/GifImageView/issues/46

I got a hint from the following line of GifDecoder.java which can play the GIF without glitch:
https://gist.github.com/keewon/6e472002c816e5d9b80432b56d799e90#file-gifdecoder-java-L94

Can test with following image:
![cat](https://cloud.githubusercontent.com/assets/227190/21515530/05a5e0aa-cd14-11e6-8e90-95e2a480ff88.gif)
